### PR TITLE
Add state space model from BRITS paper

### DIFF
--- a/docs/src/imputation.md
+++ b/docs/src/imputation.md
@@ -205,6 +205,7 @@ init_imputation_problem(::TrainedMPS, ::Matrix)
 MPS_impute
 get_cdfs
 trendy_sine
+MPSTime.state_space
 ```
 
 Internal imputation methods:

--- a/src/Simulation/toy_data.jl
+++ b/src/Simulation/toy_data.jl
@@ -122,8 +122,8 @@ N(0, `sigma`) and lag order `s`. Time series are generated from the following mo
 \\lambda_t = \\lambda_{t-1} + \\zeta_{t}
 \\theta_t = \\sum_{j=1}^{s-1} - \\theta_{t-j} + \\omega_t
 ```
-where ``x_t`` is the ``t``-th value in the time series, and the residual terms ``eta_t``, ``xi_t``, ``zeta_t`` and ``omega_t`` are
-randomly drawn from a normal distribution ``N(0, sigma)``.
+where ``\\x_t`` is the ``\\t``-th value in the time series, and the residual terms ``\\eta_t``, ``\\xi_t``, ``\\zeta_t`` and ``\\omega_t`` are
+randomly drawn from a normal distribution ``\\N(0, \\sigma)``.
 
 # Arguments
 - `T` -- Time series length.

--- a/src/Simulation/toy_data.jl
+++ b/src/Simulation/toy_data.jl
@@ -132,12 +132,12 @@ randomly drawn from a normal distribution ``\\N(0, \\sigma)``.
 # Keyword Arguments
 - `s` -- Lag order (optional, default: `2`).
 - `sigma` -- Noise standard deviation (optional, default: `0.3`).
-- `rng` -- Random number generator of type `AbstractRNG` (optional, default: `Xoshiro(123)`).
+- `rng` -- Random number generator of type `AbstractRNG` (optional, default: `nothing`).
 
 # Returns 
 A Matrix{Float64} of shape (n, T) containing the simulated time-series instances. 
 """
-function state_space(T::Int, n::Int; s::Int=2, sigma::Float64=0.3, rng::AbstractRNG=Xoshiro(123))
+function state_space(T::Int, n::Int; s::Int=2, sigma::Float64=0.3, rng::Union{Nothing, AbstractRNG}=nothing)
     if s < 2
         throw(ArgumentError("Lag order s must be ≥ 2."))
     end

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -1,6 +1,7 @@
 [deps]
+Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"
 JLD2 = "033835bb-8acc-5ee8-8aae-3f567f8a3819"
+Random = "9a3f8284-a2c9-5f02-9a11-845980a1fd5c"
 Statistics = "10745b16-79ce-11e8-11f9-7d13ad32a3b2"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"
 TestItems = "1c621080-faea-4a02-84b6-bbd5e436b8fe"
-Aqua = "4c88cf16-eb10-579e-8560-4a9242c79595"

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,6 +2,7 @@ using MPSTime
 using Test
 using TestItems
 using Aqua
+using Random
 
 @testset "Aqua.jl Quality Assurance" begin
     Aqua.test_ambiguities(MPSTime) # test for method ambiguities

--- a/test/simulation_tests.jl
+++ b/test/simulation_tests.jl
@@ -129,3 +129,20 @@ end
     @test all(x -> 0.0 <= x <= 2pi, info_default[:phase])
 
 end
+
+@testset "state space model" begin
+    # basic functionality tests
+    T = 100;
+    n = 10;
+    X = MPSTime.state_space(T, n);
+    @test isa(X, Matrix)
+    @test size(X) == (n, T)
+    # check reproducibility
+    X1 = MPSTime.state_space(T, n; rng=Xoshiro(123))
+    X2 =  MPSTime.state_space(T, n; rng=Xoshiro(123))
+    @test isequal(X1, X2)
+    @test !isequal(X, X1)
+    # check errors
+    @test_throws ArgumentError MPSTime.state_space(T, n; s=1)
+    @inferred MPSTime.state_space(T, n);
+end


### PR DESCRIPTION
Added the state space model from the original BRITS paper for the generation of synthetic univariate time series data. 